### PR TITLE
fix: Correct 'Tahun Ajaran' to 'Tahun Pelajaran'

### DIFF
--- a/src/modules/students/util/student-export.pdf.util.ts
+++ b/src/modules/students/util/student-export.pdf.util.ts
@@ -621,7 +621,7 @@ export class StudentExportPdfUtil extends PDFUtil {
     const headerData: { title: string; value: string }[] = [
       { title: 'Kelas', value: classReport.classType },
       {
-        title: 'Tahun Ajaran',
+        title: 'Tahun Pelajaran',
         value: Array.from(new Set(classReport.schoolYears)).join(' '),
       },
       {


### PR DESCRIPTION
Update inaccurate label in student report PDF.

Improve report accuracy and clarity.